### PR TITLE
add flake.nix and flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,166 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "nix"
+        ],
+        "gitignore": [
+          "nix"
+        ],
+        "nixpkgs": [
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1742029588,
+        "narHash": "sha256-Fwdlp/mw5cAlWhMtRU2Zo7rgB/cxMs+vBY6s9e4Ulgs=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "e4bda20918ad2af690c2e938211a7d362548e403",
+        "type": "github"
+      },
+      "original": {
+        "id": "nix",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734359947,
+        "narHash": "sha256-1Noao/H+N8nFB4Beoy8fgwrcOQLVm9o4zKW1ODaqK9E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48d12d5e70ee91fe8481378e540433a7303dbf6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1741969460,
+        "narHash": "sha256-SCNxTTBfMJV7XuTcLUfdAd6cgCGsazzi+DoPrceQrZ0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "68612419aa6c9fd5b178b81e6fabbdf46d300ea4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "A simple flake to build pass-secrets and allow it to be added to a NixOS configuration";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11-small";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nix,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+
+      overlayList = [ self.overlays.default ];
+
+      pkgsBySystem = forEachSystem (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = overlayList;
+        }
+      );
+
+    in
+    rec {
+
+      overlays.default = final: prev: { pass-secrets = final.callPackage ./package.nix { }; };
+
+      packages = forEachSystem (system: {
+        pass-secrets = pkgsBySystem.${system}.pass-secrets;
+        default = pkgsBySystem.${system}.pass-secrets;
+      });
+
+      nixosModules = import ./nixos-modules { overlays = overlayList; };
+
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,24 @@
+{ stdenv }:
+
+let
+  commit = "72dde8b51c10728fc19c646700bb0b1c0ad8c366";
+in
+stdenv.mkDerivation rec {
+  pname = "pass-secrets";
+  version = "2024-06-08";
+  src = fetchgit {
+    url = "https://github.com/nullobsi/pass-secrets";
+    rev = commit;
+    sha256 = "sha256-QP4vBNaFsLCL45Mog1A9438rCqnWgnWmRgVuL35S+4U=";
+  };
+  nativeBuildInputs = [
+    clang
+    cmake
+    sdbus-cpp
+  ];
+  buildPhase = "make -j $NIX_BUILD_CORES";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $TMP/pass-secrets-${builtins.substring 0 7 commit}/build/pass-secrets $out/bin
+  '';
+}


### PR DESCRIPTION
This PR creates a flake.nix file that allows users of NixOS to easily add pass-secrets to their systems (or build them for temporary use). This flake just installs the binary, it does not install the .desktop or systemd files. (This could be addressed if there is interest.)